### PR TITLE
Release 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fraymakers/api-types-plugin",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fraymakers/api-types-plugin",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Source code for the Fraymakers Api Types Plugin for FrayTools.",
   "private": true,
   "repository": {

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "TypeDefinitionPlugin",
   "id": "com.fraymakers.FraymakersTypes",
   "name": "Fraymakers API Types",


### PR DESCRIPTION
- New CharacterAnimationStats: chargeGlow, chargeShake, cameraShakeType
- New CameraShakeType constants
- New VfxLayer constants (for use with the layer field for VfxStats)
- New Character function: getAssistContentStat()
- HitboxStats: Fixed incorrect docstring on hitSoundOverride
- Added new SHIELD1 and SHIELD2 constants to ControlsObject and Buttons api
- New Stage functions: getBackgroundBehindContainer(), getForegroundFrontContainer()
- Updated docstring for updateLightboxStats() to inform of no-op
- New StatusEffectType constant: WALK_SPEED_CAP_MULTIPLIER
- New MatchEvent constant: MATCH_BEFORE_END_GRAPHIC_SHOWN -